### PR TITLE
Add dependent service info when dependency resolution fails

### DIFF
--- a/src/DICIT/Container.php
+++ b/src/DICIT/Container.php
@@ -48,10 +48,16 @@ class Container {
     public function get($serviceName) {
         if (count($this->config) > 0) {
             if (array_key_exists('classes', $this->config) && array_key_exists($serviceName, $this->config['classes'])) {
-                return $this->loadService($serviceName, $this->config['classes'][$serviceName]);
+                try {
+                    return $this->loadService($serviceName, $this->config['classes'][$serviceName]);
+                }
+                catch (\DICIT\UnknownDefinitionException $ex) {
+                    throw new \RuntimeException(
+                        sprintf("Dependency '%s' not found while trying to build '%s'.", $ex->getServiceName(), $serviceName));
+                }
             }
             else {
-                throw new \RuntimeException('Class not configured ' . $serviceName);
+                throw new \DICIT\UnknownDefinitionException($serviceName);
             }
         }
         else {

--- a/src/DICIT/UnknownDefinitionException.php
+++ b/src/DICIT/UnknownDefinitionException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DICIT;
+
+class UnknownDefinitionException extends \RuntimeException
+{
+    private $serviceName;
+    
+    public function __construct($serviceName) {
+        parent::__construct('Class not configured : ' . $serviceName);
+        
+        $this->serviceName = $serviceName;
+    }
+    
+    public function getServiceName()
+    {
+        return $this->serviceName;
+    }
+}


### PR DESCRIPTION
Allows to display in exception message the name of the service being built when a dependency is not found (ie. service 'A' not found while trying to build service 'B')
